### PR TITLE
Enable edoc preprocessing.

### DIFF
--- a/src/autohelp.erl
+++ b/src/autohelp.erl
@@ -5,7 +5,7 @@
 
 parse_transform(AST, _Options) ->
   [File|_] = [FileName || {attribute, _, file, {FileName, _}} <- AST],
-  try edoc:get_doc(File) of
+  try edoc:get_doc(File, [{preprocess, true}]) of
     {Module, #xmlElement{name = module} = DocXML} ->
       add_doc_from_xml(AST, Module, DocXML);
     {_Module, _} ->


### PR DESCRIPTION
By default edoc does not perform any preprocessing. As a result, autohelp is
unable to annotate source files that do use freaky preprocessing. This commit
enables edoc's preprocess and makes autohelp applicable to a wider range of
source code.

Signed-off-by: Brian L. Troutwine brian@troutwine.us
